### PR TITLE
Gemini APIをHTTPリクエストベースに変更

### DIFF
--- a/lib/services/gemini_service.dart
+++ b/lib/services/gemini_service.dart
@@ -1,4 +1,4 @@
-import 'package:google_generative_ai/google_generative_ai.dart';
+import 'package:http/http.dart' as http;
 
 class GeminiService {
   static final GeminiService _instance = GeminiService._internal();
@@ -9,16 +9,18 @@ class GeminiService {
 
   GeminiService._internal();
 
-  final model = GenerativeModel(
-    model: 'gemini-1.5-flash',
-    apiKey: const String.fromEnvironment('GEMINI_API_KEY'),
-  );
+  final fetchUrl = '${const String.fromEnvironment('BASE_URL')}/ask-gemini';
 
   Future<String> generateContent({
     required String prompt,
   }) async {
-
-    final response = await model.generateContent([Content.text(prompt)]);
-    return response.text ?? '結果を生成できませんでした。';
+    final response = await http.post(
+      Uri.parse(fetchUrl),
+      body: {'prompt': prompt},
+    );
+    final responseBody = response.body;
+    // レスポンスから引用符を削除
+    final content = responseBody.replaceAll('"', '').replaceAll(r'\n', '\n');
+    return content;
   }
 }

--- a/lib/services/zenn_service.dart
+++ b/lib/services/zenn_service.dart
@@ -32,7 +32,7 @@ class ZennService {
     final apiArticlesUrl =
         'https://zenn.dev/api/articles?page=1&username=$zennAccount&count=96&order=latest';
     final response = await http.post(
-        Uri.parse('https://api-ej5rtjryya-uc.a.run.app/proxy'),
+        Uri.parse('${const String.fromEnvironment('BASE_URL')}/proxy'),
         body: {'url': apiArticlesUrl});
     // final response = await http.get(Uri.parse(apiArticlesUrl));
     final responseBody = jsonDecode(response.body);


### PR DESCRIPTION
.env
```
BASE_URL=(firebase funcionやCloud Runのエントリポイント)
```
を定義する必要があります。
API_KEYは消してしまって大丈夫です。
バックエンドの同じ名前のプルリクと同期しています。

かなり整形が力技なので誰か気になった場合は好きに直してください
![CleanShot 2025-02-05 at 20 05 53](https://github.com/user-attachments/assets/89fc513b-4b00-4697-9159-816856efe46e
![CleanShot 2025-02-05 at 20 16 22@2x](https://github.com/user-attachments/assets/22c75309-f75e-41f4-9eef-0766f9fae217)
)
