### PR TITLE
スコアによってグラフの目盛りがバラバラになる問題を修正

### DIFF
--- a/lib/classes/FixedTicksRadarChartData.dart
+++ b/lib/classes/FixedTicksRadarChartData.dart
@@ -1,0 +1,35 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+class FixedTicksRadarChartData extends RadarChartData {
+  FixedTicksRadarChartData({
+    required List<RadarDataSet> dataSets,
+    required List<String> titles,
+  }) : super(
+          radarShape: RadarShape.circle,
+          dataSets: dataSets,
+          radarBackgroundColor: Colors.transparent,
+          borderData: FlBorderData(show: false),
+          radarBorderData: const BorderSide(color: Colors.black),
+          titleTextStyle: const TextStyle(color: Colors.black, fontSize: 14.0),
+          titlePositionPercentageOffset: 0.2,
+          getTitle: (index, angle) {
+            return RadarChartTitle(text: titles[index]);
+          },
+          tickCount: 9, // 目盛りの数（0, 25, 50, 75, 100 の5個）
+          ticksTextStyle: const TextStyle(color: Colors.grey, fontSize: 12),
+          gridBorderData: BorderSide(color: Colors.grey),
+          tickBorderData: BorderSide(color: Colors.grey),
+          isMinValueAtCenter: false,
+        );
+
+  @override
+  RadarEntry get minEntry {
+    return RadarEntry(value: 10);
+  }
+
+  @override
+  RadarEntry get maxEntry {
+    return RadarEntry(value: 100);
+  }
+}

--- a/lib/result.dart
+++ b/lib/result.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:zenn_hackthon_2025/classes/FixedTicksRadarChartData.dart';
 
 class Result extends StatelessWidget {
   const Result({
@@ -115,8 +116,7 @@ ${resultJson['next_step']}
                   child: SizedBox(
                     height: 300,
                     child: RadarChart(
-                      RadarChartData(
-                        radarShape: RadarShape.circle,
+                      FixedTicksRadarChartData(
                         dataSets: [
                           RadarDataSet(
                             dataEntries: radarData.values
@@ -128,21 +128,7 @@ ${resultJson['next_step']}
                             borderWidth: 2,
                           ),
                         ],
-                        radarBackgroundColor: Colors.transparent,
-                        borderData: FlBorderData(show: false),
-                        radarBorderData: const BorderSide(color: Colors.black),
-                        titleTextStyle:
-                            TextStyle(color: Colors.black, fontSize: 18.0),
-                        titlePositionPercentageOffset: 0.2,
-                        getTitle: (index, angle) {
-                          final keys = radarData.keys.toList();
-                          return RadarChartTitle(text: keys[index]);
-                        },
-                        tickCount: 4,
-                        ticksTextStyle:
-                            const TextStyle(color: Colors.grey, fontSize: 12),
-                        gridBorderData: const BorderSide(color: Colors.grey),
-                        tickBorderData: const BorderSide(color: Colors.grey),
+                        titles: radarData.keys.toList(),
                       ),
                     ),
                   ),


### PR DESCRIPTION
出力されたスコアによってグラフの目盛りがバラバラになってしまう問題を修正しました。


情報ソース  
https://take4-blue.com/program/flutter-dart/flutter-fl_chart%E3%81%AEradarchart%E3%81%AE%E5%88%A9%E7%94%A81/
